### PR TITLE
Fixed typographical error, changed abritrary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ It will appear in the reports and will count towards efficiency calculations. Th
 
   Creates the `$PAR_DIR` directory and the sample hooks in `$PAR_DIR/hooks`. The data store will not be created on `par init`, but when the first write operation happens (e.g. `par pomodoro start`, but not `par report`).
 
-* Initialize an abritrary directory
+* Initialize an arbitrary directory
 
           $ par init /tmp
 


### PR DESCRIPTION
nerab, I've corrected a typographical error in the documentation of the [paradeiser](https://github.com/nerab/paradeiser) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
